### PR TITLE
Prevent data loss in anonymous volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       MYSQL_PASSWORD: changeme
     restart: unless-stopped
     volumes:
-     - /var/lib/mysql
+     - mysql:/var/lib/mysql
     healthcheck:
      test: ["CMD", "mysqladmin", "ping", "--silent"]
   yotter:
@@ -24,5 +24,8 @@ services:
     ports:
       - "5000:5000"
     volumes:
-     - /usr/src/app/migrations
+     - migrations:/usr/src/app/migrations
      - ./yotter-config.json:/usr/src/app/yotter-config.json
+volumes:
+  mysql:
+  migrations:


### PR DESCRIPTION
This fixes an issue which caused my instance to lose it's database when upgrading its image.

The data loss can be replicated by:
```
docker-compose up -d
docker-compose down
```

This is because `docker-compose down` removes anonymous volumes.