### PR TITLE
Remove video thumbnails black bars with CSS

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -775,7 +775,7 @@ def getYoutubePosts(ids):
                 video.channelUrl = vid.author_detail.href
                 video.id = vid.yt_videoid
                 video.videoTitle = vid.title
-                video.videoThumb = vid.media_thumbnail[0]['url'].replace('/', '~')
+                video.videoThumb = vid.media_thumbnail[0]['url'].replace('/', '~') # TODO: remove black bars without CSS
                 video.views = vid.media_statistics['views']
                 video.description = vid.summary_detail.value
                 video.description = re.sub(r'^https?:\/\/.*[\r\n]*', '', video.description[0:120]+"...", flags=re.MULTILINE)

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -59,3 +59,13 @@
     visibility: visible;
     cursor: pointer;
 }
+
+
+
+/* Workaround for video thumbnails black bars */
+.video-thumbnail {
+    overflow: hidden;
+}
+.video-thumbnail > img {
+    margin: -28px 0;
+}

--- a/app/templates/_video_item.html
+++ b/app/templates/_video_item.html
@@ -1,5 +1,5 @@
 <div class="card">
-    <div class="image">
+    <div class="image video-thumbnail">
         <img alt="Thumbnail" src="/img/{{video.videoThumb.replace('/', '~')}}">
     </div>
     <div class="content">


### PR DESCRIPTION
This is a workaround that removes the bars with css.

The best way to remove the bars would be in the backend, so the server doesn't send useless pixels, this approach would reduce bundle size, and make the page slightly faster.