### PR TITLE
Add support for multi-architecture Docker builds.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .git
+.github
 .gitignore
+cache
 Dockerfile
 docker-compose.yml
 LICENSE

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,45 @@
+name: Docker Multi-Architecture Build
+
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+    branches:
+      - dev-indep
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: cache docker cache
+        uses: actions/cache@v2.1.1
+        with:
+          path: ${{ github.workspace }}/cache
+          key: ${{ runner.os }}-docker-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-docker-${{ hashFiles('**/requirements.txt') }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ytorg/yotter:latest
+          cache-from: type=local,src=cache
+          cache-to: type=local,dest=cache


### PR DESCRIPTION
Hey @pluja,

Before we merge this are a few changes need to be done:
- Add DOCKER_USERNAME as a repository/organisation secret on GitHub
- Add DOCKER_PASSWORD as a repository/organisation secret on GitHub with a PAT from DockerHub
- Disable automatic building on DockerHub

The following are the effects of this:
- There will be support for `ARM` in addition to `AMD64`
- Build caching will actually work
- Changes in the `md` files will not result in a docker build
- A non-cached build takes much longer (20m -> 2h)
- A cached build takes less than 2 minutes