### PR TITLE
Fixes ytorg/Yotter#87 and removes redundant ports option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN flask db init \
   && flask db migrate \
   && flask db upgrade
 
-CMD flask db migrate \
+CMD flask db stamp head \
+  && flask db migrate \
   && flask db upgrade \
   && gunicorn -b 0.0.0.0:5000 -w 4 yotter:app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
       DATABASE_URL: mysql+pymysql://yotter:changeme@mariadb:3306/yotter
     depends_on:
       - mariadb
-    ports:
-      - "5000:5000"
     volumes:
      - migrations:/usr/src/app/migrations
      - ./yotter-config.json:/usr/src/app/yotter-config.json


### PR DESCRIPTION
See #87 for more context regarding the `Dockerfile` changes. About the redundant `ports` option in the `yotter` service, even if it is not detected by Compose's validation mechanism, it is better to avoid duplication since the option value defined later will be applied (you can read more about it [here](https://github.com/docker/compose/issues/7465), if that interests you).

Keep up the good work :)!