### PR TITLE
Widen the UI for video.html

### DIFF
--- a/app/templates/video.html
+++ b/app/templates/video.html
@@ -3,7 +3,7 @@
 </head>
 {% extends "base.html" %}
 {% block content %}
-<div class="ui text container">
+<div style="width: 80%;" class="ui container">
     {% if info.error != None or info.playability_error != None %}
     <div class="ui center aligned text container">
         <div class="ui segment">


### PR DESCRIPTION
Easy solution for issue [#39 ](https://github.com/ytorg/Yotter/issues/39)

Semantic-UI class "text" has style "max-width" and is therefore removed and replaced with style "width: 80%"