### PR TITLE
Add rust as a build dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 COPY ./requirements.txt /usr/src/app
 
 # Build Dependencies
-RUN apk --no-cache add gcc musl-dev libffi-dev openssl-dev libxml2-dev libxslt-dev file llvm-dev make g++
+RUN apk --no-cache add gcc musl-dev libffi-dev openssl-dev libxml2-dev libxslt-dev file llvm-dev make g++ cargo rust
 
 # Python Dependencies
 RUN pip install --no-cache-dir --prefix=/install wheel cryptography gunicorn pymysql

--- a/pypy.Dockerfile
+++ b/pypy.Dockerfile
@@ -12,6 +12,12 @@ RUN apt-get update \
     && apt-get install -yq build-essential libssl-dev libffi-dev libxml2-dev libxslt-dev zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/*
 
+# install rust toolchain
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain stable -y
+
+ENV PATH=/root/.cargo/bin:$PATH
+
 # Python Dependencies
 RUN pip install --no-warn-script-location --ignore-installed --no-cache-dir --prefix=/install wheel cryptography gunicorn pymysql
 RUN pip install --no-warn-script-location --ignore-installed --no-cache-dir --prefix=/install -r requirements.txt


### PR DESCRIPTION
This is because the `cryptography` package now uses rust for memory safety reasons.